### PR TITLE
actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         target: ${{ matrix.target }}
         path: ''
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: firmware-${{ matrix.target }}-${{ matrix.display }}-${{ matrix.custom }}
         path: |


### PR DESCRIPTION
The build doesn't work anymore because of an upgrade in Github. This change puts our build back in line with Github.