### PR TITLE
esp_idf_version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: latest
+        esp_idf_version: v5.1
         target: ${{ matrix.target }}
         path: ''
 


### PR DESCRIPTION
the latest version v6.0 causes the build to fail and cascades in quite some failures. So this is the quick and easy solution.