### PR TITLE
heartBeat

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -64,6 +64,8 @@ static const int MEASURE_BAT_BIT = BIT7;
 
 static EventGroupHandle_t controlEventGroup;
 
+volatile bool myTaskAlive = false;
+
 enum messageHandlingResult {
     // We got a handoff back, so we get to send the next message
     CONTROL_TO_US,
@@ -74,8 +76,16 @@ enum messageHandlingResult {
 };
 
 static TimerHandle_t measureBatTimer;
+TimerHandle_t healthCheckTimer ;
 
 static void measureBatTimerCallback(TimerHandle_t xTimer) { xEventGroupSetBits(controlEventGroup, MEASURE_BAT_BIT); }
+
+static void checkMyTaskHealth(TimerHandle_t xTimer) {
+    if (!myTaskAlive) {
+        esp_restart();
+    }
+    myTaskAlive = false;  // Reset voor volgende check
+}
 
 static messageHandlingResult handleMotorMessage(ion_state * state) {
     messageType message = {};
@@ -249,8 +259,10 @@ static void my_task(void *pvParameter) {
     initMotor();
 
     measureBatTimer = xTimerCreate("measureBatTimer", (100 / portTICK_PERIOD_MS), pdTRUE, (void *)0, measureBatTimerCallback);
-
     xTimerStart(measureBatTimer, 0);
+	
+    healthCheckTimer = xTimerCreate("healthCheckTimer", 60000 / portTICK_PERIOD_MS, pdTRUE, NULL, checkMyTaskHealth);
+    xTimerStart(healthCheckTimer, 0);
 
     ion_state state = {
         .state = IDLE,
@@ -265,6 +277,8 @@ static void my_task(void *pvParameter) {
     };
 
     while(true) {
+
+        myTaskAlive = true;  // sign of life
 
         // TODO:
         // More use of timeouts


### PR DESCRIPTION
Heartbeat to reset the system if it is lost. To solve the issue that the system is stuck when the display is removed when motor is on. It may fix other hang situations. Within 2 minutes the state goes back to the begining with a reset. Kind of blunt but it seems to work and saves me from investigating all possible hang situations and how to get out without losing a healthystate. The state after startup is fine in any case I guess. Only tried this without cycling just on electronics and all seems to work.